### PR TITLE
Keybinding adjustments and debugging default improvements

### DIFF
--- a/diffviewer.go
+++ b/diffviewer.go
@@ -37,17 +37,9 @@ func (m diffModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	cmds := make([]tea.Cmd, 0)
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "down", "j":
-			break
-		case "up", "k":
-			break
-		default:
-			vp, vpCmd := m.vp.Update(msg)
-			cmds = append(cmds, vpCmd)
-			m.vp = vp
-		}
-
+        	vp, vpCmd := m.vp.Update(msg)
+        	cmds = append(cmds, vpCmd)
+        	m.vp = vp
 	case diffContentMsg:
 		m.vp.SetContent(msg.text)
 	case dimensionsMsg:

--- a/keys.go
+++ b/keys.go
@@ -14,28 +14,28 @@ type KeyMap struct {
 
 var keys = &KeyMap{
 	Up: key.NewBinding(
-		key.WithKeys("up", "k"),
-		key.WithHelp("↑/k", "prev file"),
+		key.WithKeys("up", "K"),
+		key.WithHelp("↑/K", "prev file"),
 	),
 	Down: key.NewBinding(
-		key.WithKeys("down", "j"),
-		key.WithHelp("↓/j", "next file"),
+		key.WithKeys("down", "J"),
+		key.WithHelp("↓/J", "next file"),
 	),
 	CtrlD: key.NewBinding(
 		key.WithKeys("ctrl+d"),
-		key.WithHelp("ctrl+d", "diff down"),
+		key.WithHelp("j/ctrl+d", "diff down"),
 	),
 	CtrlU: key.NewBinding(
 		key.WithKeys("ctrl+u"),
-		key.WithHelp("ctrl+u", "diff up"),
+		key.WithHelp("k/ctrl+u", "diff up"),
 	),
 	ToggleFileTree: key.NewBinding(
-		key.WithKeys("e"),
-		key.WithHelp("e", "toggle file tree"),
+		key.WithKeys("t"),
+		key.WithHelp("t", "toggle file tree"),
 	),
 	Search: key.NewBinding(
-		key.WithKeys("t"),
-		key.WithHelp("t", "search files"),
+		key.WithKeys("/"),
+		key.WithHelp("/", "search files"),
 	),
 	Quit: key.NewBinding(
 		key.WithKeys("q", "ctrl+c"),

--- a/main.go
+++ b/main.go
@@ -347,16 +347,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	var fileErr error
-	logFile, fileErr := os.OpenFile("debug.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if fileErr == nil {
-		log.SetOutput(logFile)
-		log.SetTimeFormat(time.Kitchen)
-		log.SetReportCaller(true)
-		log.SetLevel(log.DebugLevel)
-		defer logFile.Close()
-		log.SetOutput(logFile)
-		log.Debug("Starting diffnav, logging to debug.log")
+	if os.Getenv("DEBUG") == "true" {
+        	var fileErr error
+        	logFile, fileErr := os.OpenFile("debug.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+    		defer logFile.Close()
+
+		logger, _ := tea.LogToFile("debug.log", "debug")
+		defer logger.Close()
+
+        	if fileErr == nil {
+        		log.SetOutput(logFile)
+        		log.SetTimeFormat(time.Kitchen)
+        		log.SetReportCaller(true)
+        		log.SetLevel(log.DebugLevel)
+        		log.SetOutput(logFile)
+        		log.Debug("Starting diffnav, logging to debug.log")
+        	}
 	}
 
 	reader := bufio.NewReader(os.Stdin)
@@ -372,11 +378,6 @@ func main() {
 			fmt.Println("Error getting input:", err)
 			os.Exit(1)
 		}
-	}
-
-	if os.Getenv("DEBUG") == "true" {
-		logger, _ := tea.LogToFile("debug.log", "debug")
-		defer logger.Close()
 	}
 
 	input := ansi.Strip(b.String())

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func newModel(input string) mainModel {
 	m.search.KeyMap.AcceptSuggestion = key.NewBinding(key.WithKeys("tab"))
 	m.search.Prompt = " "
 	m.search.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	m.search.Placeholder = "Filter files 🅃"
+	m.search.Placeholder = "Filter files"
 	m.search.PlaceholderStyle = lipgloss.NewStyle().MaxWidth(lipgloss.Width(m.search.Placeholder)).Foreground(lipgloss.Color("8"))
 	m.search.Width = constants.OpenFileTreeWidth - 5
 
@@ -139,24 +139,10 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		if m.searching {
-			switch msg.String() {
-			case "ctrl+n":
-				if m.searching {
-					m.resultsCursor = min(len(m.files)-1, m.resultsCursor+1)
-					m.resultsVp.LineDown(1)
-				}
-			case "ctrl+p":
-				if m.searching {
-					m.resultsCursor = max(0, m.resultsCursor-1)
-					m.resultsVp.LineUp(1)
-				}
-			}
-		}
 		switch msg.String() {
 		case "ctrl+c", "q":
 			return m, tea.Quit
-		case "t":
+		case "/":
 			m.searching = true
 			m.search.Width = m.sidebarWidth() - 5
 			m.search.SetValue("")
@@ -170,18 +156,18 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.diffViewer = df
 			cmds = append(cmds, m.search.Focus())
 			return m, tea.Batch(cmds...)
-		case "e":
+		case "t":
 			m.isShowingFileTree = !m.isShowingFileTree
 			df, dfCmd := m.setDiffViewerDimensions()
 			m.diffViewer = df
 			return m, dfCmd
-		case "up", "k", "ctrl+p":
+		case "up", "K", "ctrl+p":
 			if m.cursor > 0 {
 				m.cursor--
 				m.diffViewer, cmd = m.diffViewer.(diffModel).SetFilePatch(m.files[m.cursor])
 				cmds = append(cmds, cmd)
 			}
-		case "down", "j", "ctrl+n":
+		case "down", "J", "ctrl+n":
 			if m.cursor < len(m.files)-1 {
 				m.cursor++
 				m.diffViewer, cmd = m.diffViewer.(diffModel).SetFilePatch(m.files[m.cursor])
@@ -343,8 +329,8 @@ func main() {
 	}
 
 	if stat.Mode()&os.ModeNamedPipe == 0 && stat.Size() == 0 {
-		fmt.Println("Try piping in some text.")
-		os.Exit(1)
+		fmt.Println("No diff")
+		os.Exit(0)
 	}
 
 	if os.Getenv("DEBUG") == "true" {


### PR DESCRIPTION
This PR addresses my main two issues with this otherwise awesome project.

1. The creation of a debug.log file when running diffnav serves no purpose for the end-user, as this is pretty early software, I can see the need. Hence it is now united with the tea debug log using the environment variable check too.
2. I'm too used to scroll pagers using j and k (and others too - see #12), hence I changed the keybindings to the following:
  t: Toggle file tree
  /: Search
  J: Down in file tree
  K: Up in file tree
  j,k,ctrl+d,ctrl+u support for embedded delta view (viewport)