### PR TITLE
Copy selected file path

### DIFF
--- a/pkg/ui/keys.go
+++ b/pkg/ui/keys.go
@@ -10,6 +10,7 @@ type KeyMap struct {
 	ToggleFileTree key.Binding
 	Search         key.Binding
 	Quit           key.Binding
+	Copy           key.Binding
 }
 
 var keys = &KeyMap{
@@ -41,8 +42,21 @@ var keys = &KeyMap{
 		key.WithKeys("q", "ctrl+c"),
 		key.WithHelp("q", "quit"),
 	),
+	Copy: key.NewBinding(
+		key.WithKeys("c"),
+		key.WithHelp("c", "copy file path"),
+	),
 }
 
 func getKeys() []key.Binding {
-	return []key.Binding{keys.Up, keys.Down, keys.CtrlD, keys.CtrlU, keys.ToggleFileTree, keys.Search, keys.Quit}
+	return []key.Binding{
+		keys.Up,
+		keys.Down,
+		keys.CtrlD,
+		keys.CtrlU,
+		keys.ToggleFileTree,
+		keys.Search,
+		keys.Copy,
+		keys.Quit,
+	}
 }

--- a/pkg/ui/mainModel.go
+++ b/pkg/ui/mainModel.go
@@ -115,6 +115,11 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					cmd = m.setCursor(m.cursor + 1)
 					cmds = append(cmds, cmd)
 				}
+			case "c":
+				cmd = m.copySelectedFilePath()
+				if cmd != nil {
+					cmds = append(cmds, cmd)
+				}
 			}
 
 		case tea.WindowSizeMsg:
@@ -311,5 +316,10 @@ func (m *mainModel) setCursor(cursor int) tea.Cmd {
 	m.cursor = cursor
 	m.diffViewer, cmd = m.diffViewer.SetFilePatch(m.files[m.cursor])
 	m.fileTree = m.fileTree.SetCursor(m.cursor)
+	return cmd
+}
+
+func (m *mainModel) copySelectedFilePath() tea.Cmd {
+	cmd := m.fileTree.CopyFilePath(m.cursor)
 	return cmd
 }

--- a/pkg/ui/mainModel.go
+++ b/pkg/ui/mainModel.go
@@ -116,7 +116,7 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					cmds = append(cmds, cmd)
 				}
 			case "c":
-				cmd = m.copySelectedFilePath()
+				cmd = m.fileTree.CopyFilePath(m.cursor)
 				if cmd != nil {
 					cmds = append(cmds, cmd)
 				}
@@ -316,10 +316,5 @@ func (m *mainModel) setCursor(cursor int) tea.Cmd {
 	m.cursor = cursor
 	m.diffViewer, cmd = m.diffViewer.SetFilePatch(m.files[m.cursor])
 	m.fileTree = m.fileTree.SetCursor(m.cursor)
-	return cmd
-}
-
-func (m *mainModel) copySelectedFilePath() tea.Cmd {
-	cmd := m.fileTree.CopyFilePath(m.cursor)
 	return cmd
 }

--- a/pkg/ui/panes/filetree/filetree.go
+++ b/pkg/ui/panes/filetree/filetree.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/atotto/clipboard"
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/dlvhdr/diffnav/pkg/constants"
 	"github.com/dlvhdr/diffnav/pkg/filenode"
+	"github.com/dlvhdr/diffnav/pkg/ui/common"
 	"github.com/dlvhdr/diffnav/pkg/utils"
 )
 
@@ -42,6 +44,20 @@ func (m Model) SetCursor(cursor int) Model {
 	m.scrollSelectedFileIntoView(m.tree)
 	m.vp.SetContent(m.printWithoutRoot())
 	return m
+}
+
+func (m Model) CopyFilePath(cursor int) tea.Cmd {
+	if len(m.files) == 0 {
+		return nil
+	}
+	name := filenode.GetFileName(m.files[cursor])
+	err := clipboard.WriteAll(name)
+	if err != nil {
+		return func() tea.Msg {
+			return common.ErrMsg{Err: err}
+		}
+	}
+	return nil
 }
 
 const contextLines = 15


### PR DESCRIPTION
This pull request adds a new feature that allows copying the file path directly from the UI, making it easier to open the file in your preferred code editor.

The changes involve adding a new key binding for the copy action, updating the main model to handle the new key, and implementing the functionality to copy the file path to the clipboard.

Key changes include:

### New Key Binding for Copy Action:

* [`pkg/ui/keys.go`](diffhunk://#diff-bdc25aae97bc8761b7c820cb4bc7963d663510218cdd272b6d455621f5bef922R13): Added a new key binding for the "c" key to copy the file path. [[1]](diffhunk://#diff-bdc25aae97bc8761b7c820cb4bc7963d663510218cdd272b6d455621f5bef922R13) [[2]](diffhunk://#diff-bdc25aae97bc8761b7c820cb4bc7963d663510218cdd272b6d455621f5bef922R45-R61)

### Handling Copy Action in Main Model:

* [`pkg/ui/mainModel.go`](diffhunk://#diff-1e1c7142077539beb9497b88cbb6567c70afb619236db3704fb7923eba19cbc5R118-R122): Updated the `Update` function to handle the "c" key press and trigger the copy file path functionality.

### Implementing Copy File Path Functionality:

* `pkg/ui/panes/filetree/filetree.go`: 
  * Added the `clipboard` package for clipboard operations.
  * Added the `common` package for error handling.
  * Implemented the `CopyFilePath` method to copy the selected file's path to the clipboard.