### PR TITLE
fix: align status icons to panel width when resized

### DIFF
--- a/pkg/filenode/file_node.go
+++ b/pkg/filenode/file_node.go
@@ -16,6 +16,7 @@ type FileNode struct {
 	File    *gitdiff.File
 	Depth   int
 	YOffset int
+	Width   int
 }
 
 func (f FileNode) Path() string {
@@ -33,13 +34,19 @@ func (f FileNode) Value() string {
 		status += lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Render("")
 	}
 
+	// Use the stored width if available, otherwise fall back to constant.
+	width := f.Width
+	if width == 0 {
+		width = constants.OpenFileTreeWidth
+	}
+
 	depthWidth := f.Depth * 2
 	iconsWidth := lipgloss.Width(icon) + lipgloss.Width(status)
-	nameMaxWidth := constants.OpenFileTreeWidth - depthWidth - iconsWidth
+	nameMaxWidth := width - depthWidth - iconsWidth
 	base := filepath.Base(f.Path())
 	name := utils.TruncateString(base, nameMaxWidth)
 
-	spacerWidth := constants.OpenFileTreeWidth - lipgloss.Width(name) - iconsWidth - depthWidth
+	spacerWidth := width - lipgloss.Width(name) - iconsWidth - depthWidth
 	if len(name) < len(base) {
 		spacerWidth = spacerWidth - 1
 	}


### PR DESCRIPTION
Status icons were positioned using a hardcoded width, causing them to stay misaligned when the file tree panel was resized. Now they properly align to the right edge at any panel width.

Before:
<img width="1860" height="649" alt="image" src="https://github.com/user-attachments/assets/e3f317b6-b1b1-4e40-a290-31c1c2567dff" />

Now:
<img width="1860" height="583" alt="image" src="https://github.com/user-attachments/assets/9e3a695f-81c9-4442-8593-f1fb56abc057" />
