### PR TITLE
Fix side-by-side toggle for directory nodes

### DIFF
--- a/pkg/ui/panes/diffviewer/diffviewer.go
+++ b/pkg/ui/panes/diffviewer/diffviewer.go
@@ -161,7 +161,7 @@ func (m *Model) GoToTop() {
 // SetSideBySide updates the diff view mode and re-renders.
 func (m *Model) SetSideBySide(sideBySide bool) tea.Cmd {
 	m.sideBySide = sideBySide
-	return diffFile(m.file, m.Width, m.sideBySide)
+	return m.diff()
 }
 
 // ScrollUp scrolls the viewport up by the given number of lines.


### PR DESCRIPTION
## Summary

- Toggling side-by-side mode on a directory node did nothing because `SetSideBySide` called `diffFile` directly, which returns nil when `m.file` is nil
- Now uses `m.diff()` which dispatches to `diffFile` or `diffDir` as appropriate