### PR TITLE
fix: sidebar search crashes

### DIFF
--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -563,7 +563,7 @@ func (m mainModel) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		if msg.Button == tea.MouseLeft {
 			// Keep coordinate check for resize border (hybrid approach).
 			sidebarWidth := m.sidebarWidth()
-			if m.isShowingFileTree && abs(msg.X-sidebarWidth) <= sidebarGrabThreshold {
+			if !m.searching && m.isShowingFileTree && abs(msg.X-sidebarWidth) <= sidebarGrabThreshold {
 				m.draggingSidebar = true
 				return m, nil
 			}
@@ -701,6 +701,11 @@ func (m mainModel) handleScroll(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m mainModel) handleSidebarDrag(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if m.searching {
+		m.draggingSidebar = false
+		return m, nil
+	}
+
 	// Hide sidebar if dragged below threshold.
 	if msg.Mouse().X < sidebarHideWidth {
 		m.isShowingFileTree = false

--- a/pkg/ui/tui_test.go
+++ b/pkg/ui/tui_test.go
@@ -124,6 +124,56 @@ func TestHiddenSidebarGrabStillShowsFileTreeWhenNotSearching(t *testing.T) {
 	}
 }
 
+func TestSearchSidebarBorderClickDoesNotStartDragging(t *testing.T) {
+	m := newTestMainModel(t)
+	m.width = 100
+	m.height = 40
+	m.isShowingFileTree = true
+	m.searching = true
+	m.fileTree.SetSize(m.config.UI.FileTreeWidth, m.mainContentHeight()-searchHeight)
+
+	updated, _ := m.handleMouse(tea.MouseClickMsg(tea.Mouse{
+		X:      m.sidebarWidth(),
+		Y:      1,
+		Button: tea.MouseLeft,
+	}))
+
+	result, ok := updated.(mainModel)
+	if !ok {
+		t.Fatalf("unexpected model type %T", updated)
+	}
+	if result.draggingSidebar {
+		t.Fatal("expected sidebar dragging to stay disabled while searching")
+	}
+}
+
+func TestSearchSidebarDragMotionIsIgnored(t *testing.T) {
+	m := newTestMainModel(t)
+	m.width = 100
+	m.height = 40
+	m.isShowingFileTree = true
+	m.searching = true
+	m.draggingSidebar = true
+	m.fileTree.SetSize(m.config.UI.FileTreeWidth, m.mainContentHeight()-searchHeight)
+
+	updated, _ := m.handleMouse(tea.MouseMotionMsg(tea.Mouse{
+		X:      40,
+		Y:      1,
+		Button: tea.MouseLeft,
+	}))
+
+	result, ok := updated.(mainModel)
+	if !ok {
+		t.Fatalf("unexpected model type %T", updated)
+	}
+	if result.draggingSidebar {
+		t.Fatal("expected search-mode drag motion to clear dragging state")
+	}
+	if result.fileTree.Width() != m.fileTree.Width() {
+		t.Fatalf("expected file tree width to remain %d, got %d", m.fileTree.Width(), result.fileTree.Width())
+	}
+}
+
 func newTestMainModel(t *testing.T) mainModel {
 	t.Helper()
 	zone.NewGlobal()


### PR DESCRIPTION
## Summary
- prevent panics on Enter or arrow keys with empty results by clamping the cursor and checking selection.
- fix the crash path triggered by hiding the file tree, entering search, pressing Enter, and showing the tree again
- render the search sidebar correctly even when the file tree itself is hidden
- add regression tests for empty search results and hidden-sidebar search flows
