### PR TITLE
show commit info when used as a pager for git show

### DIFF
--- a/pkg/ui/panes/diffviewer/diffviewer.go
+++ b/pkg/ui/panes/diffviewer/diffviewer.go
@@ -44,6 +44,12 @@ type Model struct {
 	dir        *cachedNode
 	cache      nodeCache
 	sideBySide bool
+	preamble   string
+}
+
+// SetPreamble stores the preamble text (e.g. commit metadata from git show).
+func (m *Model) SetPreamble(preamble string) {
+	m.preamble = preamble
 }
 
 func New(sideBySide bool) Model {
@@ -136,7 +142,11 @@ func (m *Model) diff() tea.Cmd {
 		}
 		m.dir = node
 		m.cache[key] = node
-		return diffDir(node, m.Width, m.sideBySide)
+		preamble := ""
+		if m.dir.path == "/" {
+			preamble = m.preamble
+		}
+		return diffDir(node, m.Width, m.sideBySide, preamble)
 	}
 
 	return nil
@@ -233,7 +243,11 @@ func (m Model) SetDirPatch(dirPath string, files []*gitdiff.File) (Model, tea.Cm
 		deletions: deleted,
 	}
 	m.cache[key] = m.dir
-	return m, diffDir(m.dir, m.Width, m.sideBySide)
+	preamble := ""
+	if dirPath == "/" {
+		preamble = m.preamble
+	}
+	return m, diffDir(m.dir, m.Width, m.sideBySide, preamble)
 }
 
 func (m *Model) GoToTop() {
@@ -285,7 +299,7 @@ func diffFile(node *cachedNode, width int, sideBySide bool) tea.Cmd {
 	}
 }
 
-func diffDir(dir *cachedNode, width int, sideBySide bool) tea.Cmd {
+func diffDir(dir *cachedNode, width int, sideBySide bool, preamble string) tea.Cmd {
 	if width == 0 || dir == nil {
 		return nil
 	}
@@ -322,8 +336,41 @@ func diffDir(dir *cachedNode, width int, sideBySide bool) tea.Cmd {
 			return common.ErrMsg{Err: err}
 		}
 
-		return diffContentMsg{cacheKey: key, text: string(out)}
+		text := string(out)
+		if preamble != "" {
+			text = renderPreamble(preamble) + "\n" + text
+		}
+		return diffContentMsg{cacheKey: key, text: text}
 	}
+}
+
+func renderPreamble(preamble string) string {
+	preamble = strings.TrimSpace(preamble)
+	if preamble == "" {
+		return ""
+	}
+
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	yellow := lipgloss.NewStyle().Foreground(lipgloss.Yellow)
+
+	var out []string
+	for _, line := range strings.Split(preamble, "\n") {
+		switch {
+		case strings.HasPrefix(line, "commit "):
+			out = append(out, dim.Render("commit ")+yellow.Render(strings.TrimPrefix(line, "commit ")))
+		case strings.HasPrefix(line, "Author:"),
+			strings.HasPrefix(line, "AuthorDate:"),
+			strings.HasPrefix(line, "Date:"),
+			strings.HasPrefix(line, "Commit:"),
+			strings.HasPrefix(line, "CommitDate:"),
+			strings.HasPrefix(line, "Merge:"):
+			out = append(out, dim.Render(line))
+		default:
+			out = append(out, line)
+		}
+	}
+
+	return strings.Join(out, "\n")
 }
 
 type diffContentMsg struct {

--- a/pkg/ui/panes/diffviewer/diffviewer_test.go
+++ b/pkg/ui/panes/diffviewer/diffviewer_test.go
@@ -1,0 +1,64 @@
+package diffviewer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestRenderPreamble_Empty(t *testing.T) {
+	if got := renderPreamble(""); got != "" {
+		t.Fatalf("expected empty string for empty preamble, got %q", got)
+	}
+	if got := renderPreamble("   \n  \n  "); got != "" {
+		t.Fatalf("expected empty string for whitespace-only preamble, got %q", got)
+	}
+}
+
+func TestRenderPreamble_GitShow(t *testing.T) {
+	preamble := `commit abc123def456
+Author: Jane Doe <jane@example.com>
+Date:   Mon Jan 1 00:00:00 2026 +0000
+
+    feat: add new feature
+
+    This is the body of the commit message.`
+
+	got := renderPreamble(preamble)
+	plain := ansi.Strip(got)
+
+	// All original content lines should be preserved in the output.
+	for _, want := range []string{
+		"commit abc123def456",
+		"Author: Jane Doe <jane@example.com>",
+		"Date:   Mon Jan 1 00:00:00 2026 +0000",
+		"feat: add new feature",
+		"This is the body of the commit message.",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, plain)
+		}
+	}
+}
+
+func TestRenderPreamble_MergeCommit(t *testing.T) {
+	preamble := `commit abc123def456
+Merge: aaa111 bbb222
+Author: Jane Doe <jane@example.com>
+Date:   Mon Jan 1 00:00:00 2026 +0000
+
+    Merge branch 'feature' into main`
+
+	got := renderPreamble(preamble)
+	plain := ansi.Strip(got)
+
+	for _, want := range []string{
+		"Merge: aaa111 bbb222",
+		"Merge branch 'feature' into main",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, plain)
+		}
+	}
+}

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -224,6 +224,7 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		m.fileTree = m.fileTree.SetFiles(m.files)
+		m.diffViewer.SetPreamble(strings.TrimSpace(msg.preamble))
 		m.diffViewer, cmd = m.diffViewer.SetDirPatch("/", m.fileTree.GetCurrNodeDesendantDiffs())
 		cmds = append(cmds, cmd)
 
@@ -444,18 +445,19 @@ func (m mainModel) View() tea.View {
 }
 
 type fileTreeMsg struct {
-	files []*gitdiff.File
+	files    []*gitdiff.File
+	preamble string
 }
 
 func (m mainModel) fetchFileTree() tea.Msg {
 	// TODO: handle error
-	files, _, err := gitdiff.Parse(strings.NewReader(m.input + "\n"))
+	files, preamble, err := gitdiff.Parse(strings.NewReader(m.input + "\n"))
 	if err != nil {
 		return common.ErrMsg{Err: err}
 	}
 	sortFiles(files)
 
-	return fileTreeMsg{files: files}
+	return fileTreeMsg{files: files, preamble: preamble}
 }
 
 func (m mainModel) footerView() string {


### PR DESCRIPTION
## What and why

If you set `git config pager.show diffnav`, the commit metadata gets dropped. `gitdiff.Parse` already returns a preamble (everything before the first `diff --git`), but it's discarded:

```go
files, _, err := gitdiff.Parse(strings.NewReader(m.input + "\n"))
//      ^ preamble tossed
```

For `git diff` the preamble is empty, so nothing changes. For `git show`, that's where the commit hash, author, date, and message live.

This PR captures it and shows it at the top of the root `/` view.

## I looked around first

- #28 asked about `git log` support. You closed it saying diffnav is for diffs, which makes sense. `git show` is different though: single commit, single diff, just with a header on top. It's the `pager.show` counterpart to `pager.diff`.
- Didn't find any other issues, PRs, or discussions about `git show` or preamble handling.

## What this does

Captures the preamble from `gitdiff.Parse` and prepends it (lightly styled) to the diff viewport content when viewing the root node. It scrolls with the diff. It doesn't appear when viewing individual files or subdirectories.

Styling: commit hash in yellow, author/date/merge lines dimmed, message as-is. Nothing fancy.

`git diff` is unaffected.

## Things I'm not sure about

- Is this something you'd want? Happy to close if `git show` is out of scope.
- The preamble lives in the scrollable diff content right now. Could also go in the header bar or a fixed section. Curious what you'd prefer.
- No config toggle for hiding it yet. Worth adding?

## Changes

- `pkg/ui/tui.go` -- capture preamble, pass it to the diff viewer
- `pkg/ui/panes/diffviewer/diffviewer.go` -- store and render preamble for root dir
- `pkg/ui/panes/diffviewer/diffviewer_test.go` -- tests for the rendering

## How to test

- `git show HEAD | diffnav` -- commit info at top of root view
- `git diff | diffnav` -- no change
- Navigate to a file, back to root -- preamble reappears
- Resize -- preamble survives re-render
- `go test ./...` passes

## Screenshot 

<img width="1936" height="1054" alt="image" src="https://github.com/user-attachments/assets/62849cdb-cab8-4c6d-858f-09261d84d5f8" />
