### PR TITLE
feat: use h/l to navigate between file tree and diff panels

### DIFF
--- a/pkg/ui/keys.go
+++ b/pkg/ui/keys.go
@@ -24,11 +24,11 @@ type KeyMap struct {
 var keys = &KeyMap{
 	ExpandNode: key.NewBinding(
 		key.WithKeys("l"),
-		key.WithHelp("l", "expand"),
+		key.WithHelp("l", "expand/focus diff"),
 	),
 	CollapseNode: key.NewBinding(
 		key.WithKeys("h"),
-		key.WithHelp("h", "collapse"),
+		key.WithHelp("h", "collapse/focus tree"),
 	),
 	ToggleNode: key.NewBinding(
 		key.WithKeys("enter"),
@@ -91,6 +91,8 @@ var keys = &KeyMap{
 func KeyGroups() [][]key.Binding {
 	return [][]key.Binding{{
 		keys.SwitchPanel,
+		keys.ExpandNode,
+		keys.CollapseNode,
 		keys.Up,
 		keys.Down,
 		keys.CtrlD,

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -114,6 +114,7 @@ func (m mainModel) Init() tea.Cmd {
 func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	var cmds []tea.Cmd
+	var keyHandled bool
 
 	// Handle mouse events regardless of search mode
 	if msg, ok := msg.(tea.MouseMsg); ok {
@@ -180,6 +181,19 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.activePanel = FileTreePanel
 				}
 			}
+		case key.Matches(msg, keys.ExpandNode):
+			if m.activePanel == FileTreePanel {
+				node := m.fileTree.GetCurrNode()
+				if _, isFile := node.GivenValue().(*filenode.FileNode); isFile {
+					m.activePanel = DiffViewerPanel
+					keyHandled = true
+				}
+			}
+		case key.Matches(msg, keys.CollapseNode):
+			if m.activePanel == DiffViewerPanel {
+				m.activePanel = FileTreePanel
+				keyHandled = true
+			}
 		case key.Matches(msg, keys.Up):
 			if m.activePanel == FileTreePanel {
 				m, cmd = m.moveCursor(-1)
@@ -236,8 +250,12 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Route messages: key messages go only to active panel, other messages go to both.
 	// Exception: ctrl+d/ctrl+u always go to diffViewer for scrolling.
+	// Skip routing if the key was already fully handled (e.g. panel switch via h/l).
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if keyHandled {
+			break
+		}
 		switch msg.String() {
 		case "ctrl+d", "ctrl+u":
 			m.diffViewer, cmd = m.diffViewer.Update(msg)


### PR DESCRIPTION
## Summary
- When the cursor is on a **file** in the file tree, pressing `l` switches focus to the diff viewer panel
- When in the diff viewer panel, pressing `h` switches focus back to the file tree
- Folder expand/collapse behavior with `h`/`l` is preserved
- Added `h`/`l` bindings to the help menu

## Test plan
- [x] On a file node, press `l` → focus moves to diff viewer
- [x] On a folder node, press `l` → folder expands (unchanged)
- [x] In the diff viewer, press `h` → focus moves back to file tree
- [x] In the file tree on a folder, press `h` → folder collapses (unchanged)
- [x] `Tab` still toggles between panels as before