### PR TITLE
feat: Add shift+tab as alias for tab to switch panels

### DIFF
--- a/pkg/ui/keys.go
+++ b/pkg/ui/keys.go
@@ -78,7 +78,7 @@ var keys = &KeyMap{
 		key.WithHelp("y", "copy file path"),
 	),
 	SwitchPanel: key.NewBinding(
-		key.WithKeys("tab"),
+		key.WithKeys("tab", "shift+tab"),
 		key.WithHelp("tab", "switch panel"),
 	),
 	OpenInEditor: key.NewBinding(


### PR DESCRIPTION
Adds `shift+tab` as an additional key binding for switching panels, so it behaves identically to `tab`.

Fixes https://github.com/dlvhdr/diffnav/issues/108