### PR TITLE
ci: add basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          args: --config=.golangci.yml --timeout=5m
+
+      - name: Test
+        run: go test -v ./...


### PR DESCRIPTION
## Summary
- Adds a CI workflow that runs on pushes to main and PRs
- Steps: build, golangci-lint, tests