### PR TITLE
fix: resolve Git repo root from CWD when possible

### DIFF
--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -93,6 +94,7 @@ type mainModel struct {
 	watchInterval     time.Duration
 	pendingCursorPath string
 	watchInFlight     bool
+	repoRoot          string
 }
 
 func New(input string, cfg config.Config) mainModel {
@@ -131,6 +133,16 @@ func New(input string, cfg config.Config) mainModel {
 	return m
 }
 
+type repoRootMsg string
+
+func (m mainModel) fetchRepoRoot() tea.Msg {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return repoRootMsg("")
+	}
+	return repoRootMsg(strings.TrimSpace(string(out)))
+}
+
 type watchTickMsg struct{ time.Time }
 
 type watchResultMsg struct {
@@ -139,7 +151,7 @@ type watchResultMsg struct {
 }
 
 func (m mainModel) Init() tea.Cmd {
-	cmds := []tea.Cmd{m.fetchFileTree, m.diffViewer.Init()}
+	cmds := []tea.Cmd{m.fetchFileTree, m.diffViewer.Init(), m.fetchRepoRoot}
 	if m.watchEnabled {
 		cmds = append(cmds, m.scheduleWatchTick())
 	}
@@ -311,6 +323,9 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.watchInFlight = true
 		return m, m.fetchWatchDiff
+
+	case repoRootMsg:
+		m.repoRoot = string(msg)
 
 	case watchResultMsg:
 		m.watchInFlight = false
@@ -967,8 +982,15 @@ func (m mainModel) openInEditor() tea.Cmd {
 		return nil
 	}
 
-	fullpath := m.fileTree.CurrNodePath()
-	c := exec.Command(editor, fullpath)
+	relpath := m.fileTree.CurrNodePath()
+	var path string
+	if m.repoRoot != "" {
+		path = filepath.Join(m.repoRoot, relpath)
+	} else {
+		path = relpath
+	}
+
+	c := exec.Command(editor, path)
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		return nil
 	})


### PR DESCRIPTION
This information is then used to construct absolute paths for the "openInEditor" functionality.
This allows paths to be correctly resolved even if you launch diffnav from somewhere *under* the repo root, instead of at it. 

Important limitation: If you use diffnav outside of a repo root entirely, or the diff chunk somehow belongs to another repo or no repo at all, editors will still be unable to resolve the path given to them.
There's not really a (sane) way to resolve the absolute path from an arbitrary relative path with no extra information.

The repo root information fetched at startup could also be used to (partially?) saturate the header in cases where it normally wouldn't be shown (I believe its only shown when the input diff has some kind of commit preamble). This is not contained in this PR, though.

# Summary

- [x] Closes issue #117 
- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

## How Did You Test this Change?

Open diffnav from *inside* the repository (*not* at the repo root), and then try to open any of the files using the 'o' shortcut.
Before: whatever your editor decides to do with a path that doesn't exist, most open a buffer with the path as the write target.
After: actually opens the file.