### PR TITLE
feat: add ui.startFoldersOpenDepth config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ ui:
 
   # Use side-by-side diff view (default: true, set false for unified)
   sideBySide: true
+
+  # How many levels of folders to open on start (-1 = all, 0 = none, 1 = first level, etc.)
+  startFoldersOpenDepth: 1
 ```
 
 | Option               | Type   | Default             | Description                                               |
@@ -139,7 +142,8 @@ ui:
 | `ui.icons`           | string | `nerd-fonts-status` | Icon style (see below for details)                        |
 | `ui.colorFileNames`  | bool   | `true`              | Color filenames by git status                             |
 | `ui.showDiffStats`   | bool   | `true`              | Show the amount of lines added / removed next to the file |
-| `ui.sideBySide`      | bool   | `true`              | Use side-by-side diff view (false for unified)            |
+| `ui.sideBySide`             | bool   | `true`              | Use side-by-side diff view (false for unified)            |
+| `ui.startFoldersOpenDepth`  | int    | `-1`                | Folder open depth on start (-1 = all, 0 = none)          |
 
 ### Icon Styles
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,16 +10,16 @@ import (
 )
 
 type UIConfig struct {
-	HideHeader      bool   `yaml:"hideHeader"`
-	HideFooter      bool   `yaml:"hideFooter"`
-	ShowFileTree    bool   `yaml:"showFileTree"`
-	FileTreeWidth   int    `yaml:"fileTreeWidth"`
-	SearchTreeWidth int    `yaml:"searchTreeWidth"`
-	Icons           string `yaml:"icons"`          // "nerd-fonts-status" (default), "nerd-fonts-simple", "nerd-fonts-filetype", "nerd-fonts-full", "unicode", "ascii"
-	ColorFileNames  bool   `yaml:"colorFileNames"` // Color filenames by git status (default: true)
-	ShowDiffStats   bool   `yaml:"showDiffStats"`  // Show the amount of lines added / removed next to the file
-	SideBySide           bool `yaml:"sideBySide"`           // Side-by-side diff view (default: true)
-	StartFoldersOpenDepth int  `yaml:"startFoldersOpenDepth"` // How many levels of folders to open on start (-1 = all, 0 = none)
+	HideHeader            bool   `yaml:"hideHeader"`
+	HideFooter            bool   `yaml:"hideFooter"`
+	ShowFileTree          bool   `yaml:"showFileTree"`
+	FileTreeWidth         int    `yaml:"fileTreeWidth"`
+	SearchTreeWidth       int    `yaml:"searchTreeWidth"`
+	Icons                 string `yaml:"icons"`                 // "nerd-fonts-status" (default), "nerd-fonts-simple", "nerd-fonts-filetype", "nerd-fonts-full", "unicode", "ascii"
+	ColorFileNames        bool   `yaml:"colorFileNames"`        // Color filenames by git status (default: true)
+	ShowDiffStats         bool   `yaml:"showDiffStats"`         // Show the amount of lines added / removed next to the file
+	SideBySide            bool   `yaml:"sideBySide"`            // Side-by-side diff view (default: true)
+	StartFoldersOpenDepth int    `yaml:"startFoldersOpenDepth"` // How many levels of folders to open on start (-1 = all, 0 = none)
 }
 
 type WatchConfig struct {
@@ -36,13 +36,13 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		UI: UIConfig{
-			HideHeader:      false,
-			HideFooter:      false,
-			ShowFileTree:    true,
-			FileTreeWidth:   30,
-			SearchTreeWidth: 50,
-			Icons:           "nerd-fonts-status",
-			ColorFileNames:  true,
+			HideHeader:            false,
+			HideFooter:            false,
+			ShowFileTree:          true,
+			FileTreeWidth:         30,
+			SearchTreeWidth:       50,
+			Icons:                 "nerd-fonts-status",
+			ColorFileNames:        true,
 			SideBySide:            true,
 			ShowDiffStats:         true,
 			StartFoldersOpenDepth: -1,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,8 @@ type UIConfig struct {
 	Icons           string `yaml:"icons"`          // "nerd-fonts-status" (default), "nerd-fonts-simple", "nerd-fonts-filetype", "nerd-fonts-full", "unicode", "ascii"
 	ColorFileNames  bool   `yaml:"colorFileNames"` // Color filenames by git status (default: true)
 	ShowDiffStats   bool   `yaml:"showDiffStats"`  // Show the amount of lines added / removed next to the file
-	SideBySide      bool   `yaml:"sideBySide"`     // Side-by-side diff view (default: true)
+	SideBySide           bool `yaml:"sideBySide"`           // Side-by-side diff view (default: true)
+	StartFoldersOpenDepth int  `yaml:"startFoldersOpenDepth"` // How many levels of folders to open on start (-1 = all, 0 = none)
 }
 
 type WatchConfig struct {
@@ -42,8 +43,9 @@ func DefaultConfig() Config {
 			SearchTreeWidth: 50,
 			Icons:           "nerd-fonts-status",
 			ColorFileNames:  true,
-			SideBySide:      true,
-			ShowDiffStats:   true,
+			SideBySide:            true,
+			ShowDiffStats:         true,
+			StartFoldersOpenDepth: -1,
 		},
 	}
 }

--- a/pkg/ui/panes/filetree/filetree.go
+++ b/pkg/ui/panes/filetree/filetree.go
@@ -208,8 +208,22 @@ func (m *Model) rebuildTree() {
 	t = collapseTree(t)
 	t, _ = truncateTree(t, 0, 0, 0, m.cfg, m.t.Width())
 	m.t.SetNodes(t)
+	if m.cfg.UI.StartFoldersOpenDepth >= 0 {
+		closeDirsBelow(m.t.Root(), m.cfg.UI.StartFoldersOpenDepth)
+	}
 	m.t.SetWidth(m.t.Width())
 	m.updateStyles()
+}
+
+func closeDirsBelow(node *tree.Node, maxOpenDepth int) {
+	for _, child := range node.ChildNodes() {
+		closeDirsBelow(child, maxOpenDepth)
+	}
+	if _, ok := node.GivenValue().(*dirnode.DirNode); ok {
+		if node.Depth() > maxOpenDepth {
+			node.Close()
+		}
+	}
 }
 
 func buildFullFileTree(files []*gitdiff.File, cfg config.Config) *tree.Node {

--- a/pkg/ui/panes/filetree/filetree_test.go
+++ b/pkg/ui/panes/filetree/filetree_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"charm.land/bubbles/v2/tree"
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
 	"github.com/dlvhdr/diffnav/pkg/config"
 	"github.com/dlvhdr/diffnav/pkg/constants"
@@ -183,5 +184,89 @@ func TestUncollapsableTree(t *testing.T) {
 	allNodes := tr.AllNodes()
 	if len(allNodes) != 13 {
 		t.Fatalf("expected 13 nodes, but got %d", len(allNodes))
+	}
+}
+
+func TestCloseDirsBelowDepthZero(t *testing.T) {
+	f, err := os.Open("testdata/multiple_files.diff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, _, err := gitdiff.Parse(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := buildFullFileTree(files, config.Config{})
+	tr = collapseTree(tr)
+
+	treeModel := tree.New(nil, 80, 40)
+	treeModel.SetNodes(tr)
+
+	root := treeModel.Root()
+
+	allNodesBefore := root.AllNodes()
+	if len(allNodesBefore) != 4 {
+		t.Fatalf("expected 4 nodes before closing, but got %d", len(allNodesBefore))
+	}
+
+	closeDirsBelow(root, 0)
+
+	if !root.IsOpen() {
+		t.Fatal("expected root node to remain open")
+	}
+
+	allNodesAfter := root.AllNodes()
+	if len(allNodesAfter) >= len(allNodesBefore) {
+		t.Fatalf("expected fewer visible nodes after closing dirs, got %d (before: %d)",
+			len(allNodesAfter), len(allNodesBefore))
+	}
+
+	for _, node := range allNodesAfter {
+		if _, ok := node.GivenValue().(*dirnode.DirNode); ok {
+			if node.Depth() > 0 && node.IsOpen() {
+				t.Fatalf("expected directory at depth %d to be closed", node.Depth())
+			}
+		}
+	}
+}
+
+func TestCloseDirsBelowDepthOne(t *testing.T) {
+	f, err := os.Open("testdata/gh_dash_pr.diff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, _, err := gitdiff.Parse(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := buildFullFileTree(files, config.Config{})
+	tr = collapseTree(tr)
+
+	treeModel := tree.New(nil, 80, 40)
+	treeModel.SetNodes(tr)
+
+	root := treeModel.Root()
+
+	closeDirsBelow(root, 1)
+
+	if !root.IsOpen() {
+		t.Fatal("expected root node to remain open")
+	}
+
+	for _, node := range root.ChildNodes() {
+		if dir, ok := node.GivenValue().(*dirnode.DirNode); ok {
+			if !node.IsOpen() {
+				t.Fatalf("expected depth-1 directory %q to be open", dir.Name)
+			}
+			for _, child := range node.ChildNodes() {
+				if _, ok := child.GivenValue().(*dirnode.DirNode); ok {
+					if child.IsOpen() {
+						t.Fatalf("expected depth-2 directory to be closed")
+					}
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
# Summary

- [] Closes issue #...
- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

Adds `ui.startFoldersOpenDepth` config option to control how many levels deep folders are expanded when diffnav starts.

- `-1` (default): all folders open, same as current behavior
- `0`: all folders collapsed
- `1`: first level open, everything deeper is collapsed
- `N`: N levels open

**AI disclosure:** Written with Claude Code. I reviewed all changes and understand the code. The `closeDirsBelow` function recursively walks children-first, then closes any directory node whose depth exceeds `maxOpenDepth`. Children-first traversal is needed because the charm bubbles tree hides a closed node's children from iteration via lipgloss `Offset`.

## How Did You Test this Change?

- Unit tests for depth 0 (all collapsed) and depth 1 (first level open, deeper closed)
- `go test ./...` passes
- `go build ./...` clean

## Images/Videos

<!-- if relevant, please include any relevant images that show off how your feature is working -->