### PR TITLE
Added exit on esc

### DIFF
--- a/pkg/ui/keys.go
+++ b/pkg/ui/keys.go
@@ -81,7 +81,7 @@ var keys = &KeyMap{
 	),
 	Quit: key.NewBinding(
 		key.WithKeys("q", "ctrl+c", "esc"),
-		key.WithHelp("q", "quit"),
+		key.WithHelp("q/esc", "quit"),
 	),
 	Copy: key.NewBinding(
 		key.WithKeys("y"),

--- a/pkg/ui/keys.go
+++ b/pkg/ui/keys.go
@@ -80,7 +80,7 @@ var keys = &KeyMap{
 		key.WithHelp("t", "search files"),
 	),
 	Quit: key.NewBinding(
-		key.WithKeys("q", "ctrl+c"),
+		key.WithKeys("q", "ctrl+c", "esc"),
 		key.WithHelp("q", "quit"),
 	),
 	Copy: key.NewBinding(


### PR DESCRIPTION
# Summary

- Closes issue #91 

## Changes

Pressing esc will quit the application, similar to pressing q — if there is a popup message, it simply exits / closes the popup — as described by jcollie in issue #91. This is a very minor change, but I hope it's helpful. I understand that this may be configurable, but since the issue was never closed, I thought I would open a pr just in case it's considered a good change.
