### PR TITLE
fix(filetree): use forward-slash path separator for git diff paths (#121)

### DIFF
--- a/pkg/ui/panes/filetree/filetree.go
+++ b/pkg/ui/panes/filetree/filetree.go
@@ -1,8 +1,7 @@
 package filetree
 
 import (
-	"os"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -241,8 +240,13 @@ func buildFullFileTree(files []*gitdiff.File, cfg config.Config) *tree.Node {
 		subTree := t
 
 		name := filenode.GetFileName(file)
-		dir := filepath.Dir(name)
-		parts := strings.Split(dir, string(os.PathSeparator))
+		// git diff always emits forward-slash paths regardless of host OS, so
+		// use the path package (forward-slash) rather than filepath /
+		// os.PathSeparator. On Windows the latter would split on `\\` and
+		// never find the `/` separators, leaving every file as a flat root
+		// child with no directory hierarchy. See #121.
+		dir := path.Dir(name)
+		parts := strings.Split(dir, "/")
 		existingPath := ""
 
 		// walk the tree to find existing path
@@ -252,7 +256,7 @@ func buildFullFileTree(files []*gitdiff.File, cfg config.Config) *tree.Node {
 			for _, child := range children {
 				if dir, ok := child.GivenValue().(*dirnode.DirNode); ok && dir.Name == part {
 					subTree = child
-					existingPath = existingPath + part + string(os.PathSeparator)
+					existingPath = existingPath + part + "/"
 					found = true
 					// found a part of the path, continue to the subtree
 					break
@@ -265,7 +269,7 @@ func buildFullFileTree(files []*gitdiff.File, cfg config.Config) *tree.Node {
 
 		// path does not exist from this point, need to create it
 		leftover := strings.TrimPrefix(name, existingPath)
-		parts = strings.Split(leftover, string(os.PathSeparator))
+		parts = strings.Split(leftover, "/")
 		for i, part := range parts {
 			var c *tree.Node
 			if i == len(parts)-1 {
@@ -277,7 +281,7 @@ func buildFullFileTree(files []*gitdiff.File, cfg config.Config) *tree.Node {
 			} else {
 				dirNode := dirnode.DirNode{
 					Name:     part,
-					FullPath: filepath.Join(existingPath, filepath.Join(parts[:i]...), part),
+					FullPath: path.Join(existingPath, path.Join(parts[:i]...), part),
 				}
 				c = tree.Root(&dirNode)
 				subTree.Child(c)
@@ -341,8 +345,8 @@ func collapseTree(t *tree.Node) *tree.Node {
 			}
 
 			newDir := dirnode.DirNode{
-				FullPath: filepath.Join(rootDir.FullPath, dir.Name),
-				Name:     filepath.Join(rootDir.Name, dir.Name),
+				FullPath: path.Join(rootDir.FullPath, dir.Name),
+				Name:     path.Join(rootDir.Name, dir.Name),
 			}
 			children := make([]any, 0)
 			for _, c := range child.ChildNodes() {


### PR DESCRIPTION
Closes #121.

## What this fixes

On native Windows, the file tree pane shows every file as a flat list at the root level — no directory hierarchy is rendered. Reported by @abdmoh123 in #121, with the symptom verified on multiple Windows machines and confirmed working on Linux + WSL.

## Root cause

`buildFullFileTree` (and `collapseTree`) split and join paths using `os.PathSeparator` and `filepath.{Dir,Join}`. `git diff` always emits **forward-slash** paths regardless of host OS, but on Windows `os.PathSeparator == '\'`. So:

```go
strings.Split("graphql-server/tests", string(os.PathSeparator))
// Linux:   ["graphql-server", "tests"]   ← splits correctly
// Windows: ["graphql-server/tests"]      ← single element, no split
```

Every file gets walked as a single path component, never matches an existing directory in the tree, and ends up as a top-level file child of the root. Hence the flat list @abdmoh123 saw.

## Fix

Swap to the `path` package (forward-slash, OS-agnostic) for everything that handles git-supplied paths. Six call sites changed in `pkg/ui/panes/filetree/filetree.go`:

| Before | After |
|---|---|
| `filepath.Dir(name)` | `path.Dir(name)` |
| `string(os.PathSeparator)` (×3) | `"/"` |
| `filepath.Join(...)` (×3) | `path.Join(...)` |

Imports trimmed: drop `"os"` and `"path/filepath"`, add `"path"`. Net: +13 / −9 lines, single file.

## Verification

Empirically tested both platforms before opening this PR — the existing test suite is the regression test:

| Platform | Pre-fix | Post-fix |
|---|---|---|
| Windows (Go 1.26.2 native) | `TestBuildFullFileTree` fails: *expected 5 nodes, but got 3* | All tests pass |
| Linux (`golang:1.26` Docker container) | All tests pass | All tests pass — byte-for-byte identical |

Linux behavior is unchanged because `os.PathSeparator == '/'` on Linux already, and `path.{Dir,Join}` produce identical output to `filepath.{Dir,Join}` for forward-slash inputs. The fix only affects Windows code paths where the previous behavior was already broken.

`TestBuildFullFileTree`, `TestCollapseTree`, `TestUncollapsableTree`, and `TestCloseDirsBelowDepth*` all flip from failing to passing on Windows under the fix; no new tests were needed.

## Side benefits beyond the file-tree rendering

`DirNode.FullPath` is also used to:

- Match against paths in `SetCursorByPath` (filetree.go:188) — used for cursor positioning. Pre-fix on Windows, paths stored as `"a\b"` would never match git-supplied `"a/b"`. Post-fix, they match.
- Pass to `SetDirPatch` in `tui.go:1349` — the dir-patch viewer for browsing all changes under a directory. Same fix applies.
- Get copied to clipboard via `CurrNodePath`. Post-fix, copied paths use `/` everywhere, which is what users will paste back into git commands regardless of host OS.

So the fix incidentally repairs cursor positioning and the dir-patch view on Windows alongside the visible tree rendering.

## Credit

Original report and reproduction across multiple Windows machines and config states by @abdmoh123 in #121. They isolated it to native Windows (Linux and WSL work fine), tested with multiple terminal emulators, and confirmed the issue reproduces with default config — saving a lot of triage work.