### PR TITLE
feat: visual select mode (v) for native text selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,13 @@ If you want the exact delta configuration I'm using - [it can be found here](htt
 | <kbd>i</kbd>                | Cycle icon style                 |
 | <kbd>o</kbd>                | Open file in $EDITOR             |
 | <kbd>s</kbd>                | Toggle side-by-side/unified view |
+| <kbd>M</kbd>                | Toggle mouse capture (for native text selection / copy) |
 | <kbd>Tab</kbd>              | Switch focus between the panes   |
 | <kbd>q</kbd>                | Quit                             |
+
+While mouse capture is on, your terminal can't do its native click-and-drag selection. Press <kbd>M</kbd> to release the mouse so you can select and copy lines from the diff (the footer shows `mouse off`); press <kbd>M</kbd> again to restore mouse scroll/click. Tip: in side-by-side mode the selection spans both columns — switch to unified with <kbd>s</kbd> first, or use your terminal's block-select modifier (Option+drag in iTerm2 / Terminal.app, Alt+drag in many Linux terminals).
+
+Most terminals (iTerm2, Terminal.app, Alacritty, kitty, WezTerm, GNOME Terminal) also let you hold <kbd>Shift</kbd> while dragging to bypass mouse capture without toggling.
 
 ## Discord
 

--- a/README.md
+++ b/README.md
@@ -226,11 +226,11 @@ If you want the exact delta configuration I'm using - [it can be found here](htt
 | <kbd>i</kbd>                | Cycle icon style                 |
 | <kbd>o</kbd>                | Open file in $EDITOR             |
 | <kbd>s</kbd>                | Toggle side-by-side/unified view |
-| <kbd>M</kbd>                | Toggle mouse capture (for native text selection / copy) |
+| <kbd>v</kbd>                | Visual select mode (release mouse for native text selection / copy) |
 | <kbd>Tab</kbd>              | Switch focus between the panes   |
 | <kbd>q</kbd>                | Quit                             |
 
-While mouse capture is on, your terminal can't do its native click-and-drag selection. Press <kbd>M</kbd> to release the mouse so you can select and copy lines from the diff (the footer shows `mouse off`); press <kbd>M</kbd> again to restore mouse scroll/click. Tip: in side-by-side mode the selection spans both columns — switch to unified with <kbd>s</kbd> first, or use your terminal's block-select modifier (Option+drag in iTerm2 / Terminal.app, Alt+drag in many Linux terminals).
+While mouse capture is on, your terminal can't do its native click-and-drag selection. Press <kbd>v</kbd> to enter visual select mode — this releases the mouse so you can select and copy lines from the diff (the footer shows `visual select`); press <kbd>v</kbd> again to restore mouse scroll/click. Tip: in side-by-side mode the selection spans both columns — switch to unified with <kbd>s</kbd> first, or use your terminal's block-select modifier (Option+drag in iTerm2 / Terminal.app, Alt+drag in many Linux terminals).
 
 Most terminals (iTerm2, Terminal.app, Alacritty, kitty, WezTerm, GNOME Terminal) also let you hold <kbd>Shift</kbd> while dragging to bypass mouse capture without toggling.
 

--- a/pkg/ui/keys.go
+++ b/pkg/ui/keys.go
@@ -24,6 +24,7 @@ type KeyMap struct {
 	ToggleIconStyle key.Binding
 	ToggleHelp      key.Binding
 	ToggleMessage   key.Binding
+	ToggleMouse     key.Binding
 }
 
 var keys = &KeyMap{
@@ -111,6 +112,10 @@ var keys = &KeyMap{
 		key.WithKeys("m"),
 		key.WithHelp("m", "commit info"),
 	),
+	ToggleMouse: key.NewBinding(
+		key.WithKeys("M"),
+		key.WithHelp("M", "toggle mouse (text select)"),
+	),
 }
 
 func KeyGroups() [][]key.Binding {
@@ -133,6 +138,7 @@ func KeyGroups() [][]key.Binding {
 		keys.ToggleIconStyle,
 	}, {
 		keys.ToggleMessage,
+		keys.ToggleMouse,
 		keys.ToggleHelp,
 		keys.Quit,
 	}}

--- a/pkg/ui/keys.go
+++ b/pkg/ui/keys.go
@@ -113,8 +113,8 @@ var keys = &KeyMap{
 		key.WithHelp("m", "commit info"),
 	),
 	ToggleMouse: key.NewBinding(
-		key.WithKeys("M"),
-		key.WithHelp("M", "toggle mouse (text select)"),
+		key.WithKeys("v"),
+		key.WithHelp("v", "visual select"),
 	),
 }
 

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -95,6 +95,7 @@ type mainModel struct {
 	pendingCursorPath string
 	watchInFlight     bool
 	repoRoot          string
+	mouseDisabled     bool
 }
 
 func New(input string, cfg config.Config) mainModel {
@@ -255,6 +256,10 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.search.SetWidth(m.searchWidth())
 			dfCmd := m.diffViewer.SetSize(m.width-sidebarWidth, h)
 			cmds = append(cmds, dfCmd)
+		case key.Matches(msg, keys.ToggleMouse):
+			m.mouseDisabled = !m.mouseDisabled
+			m.draggingSidebar = false
+			return m, tea.Batch(cmds...)
 		case key.Matches(msg, keys.ToggleIconStyle):
 			m.cycleIconStyle()
 		case key.Matches(msg, keys.ToggleDiffView):
@@ -488,7 +493,11 @@ func (m mainModel) searchUpdate(msg tea.Msg) (mainModel, []tea.Cmd) {
 func (m mainModel) View() tea.View {
 	var view tea.View
 	view.AltScreen = true
-	view.MouseMode = tea.MouseModeAllMotion
+	if m.mouseDisabled {
+		view.MouseMode = tea.MouseModeNone
+	} else {
+		view.MouseMode = tea.MouseModeAllMotion
+	}
 
 	view.KeyboardEnhancements.ReportEventTypes = true
 	// Determine colors based on active panel.
@@ -824,6 +833,12 @@ func (m mainModel) footerView() string {
 		watchLabel := base.Foreground(lipgloss.Yellow).Render("watching: " + m.watchCmd)
 		parts = append(parts, sep, watchLabel)
 		usedWidth += lipgloss.Width(sep) + lipgloss.Width(watchLabel)
+	}
+
+	if m.mouseDisabled {
+		mouseLabel := base.Foreground(lipgloss.Yellow).Render("mouse off")
+		parts = append(parts, sep, mouseLabel)
+		usedWidth += lipgloss.Width(sep) + lipgloss.Width(mouseLabel)
 	}
 
 	spacing := base.Render(strings.Repeat(" ", max(0, m.width-usedWidth)))

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -836,7 +836,7 @@ func (m mainModel) footerView() string {
 	}
 
 	if m.mouseDisabled {
-		mouseLabel := base.Foreground(lipgloss.Yellow).Render("mouse off")
+		mouseLabel := base.Foreground(lipgloss.Yellow).Render("visual select")
 		parts = append(parts, sep, mouseLabel)
 		usedWidth += lipgloss.Width(sep) + lipgloss.Width(mouseLabel)
 	}


### PR DESCRIPTION
## Summary

Adds <kbd>v</kbd> to toggle bubbletea's mouse capture between `AllMotion` and `None` — a "visual select mode" that releases the mouse so the terminal can do its native click-and-drag selection. Useful for copying lines from the diff (e.g. when reviewing edits via `--watch` and pasting feedback elsewhere).

A small `visual select` indicator appears in the footer (mirroring the existing `watching:` label) so the mode change is discoverable.

## Why

With `tea.MouseModeAllMotion` always on, every drag is captured by the app and terminal-native text selection is suppressed. There was no way to copy a snippet from the diff. Toggling capture is the standard TUI answer (lazygit, k9s, etc.) and keeps all existing mouse UX (sidebar drag, scroll wheel, zone clicks) intact when the mode is off.

## Notes

- Bound to <kbd>v</kbd> for the vim "visual select" mnemonic; a single keystroke that doesn't overlap with other bindings.
- `MouseModeNone` is read by bubbletea v2 in `View()` each frame; the renderer emits the right CSI sequences when the mode changes, so toggling is instant.
- In side-by-side view, native selection spans both columns + divider. Two workarounds (no extra code): switch to unified with <kbd>s</kbd> first, or use the terminal's block-select modifier (Option+drag in iTerm2 / Terminal.app, Alt+drag in many Linux terminals). Both are documented in the README.
- Most terminals already support <kbd>Shift</kbd>+drag to bypass mouse capture without toggling — also mentioned in the README for users who don't want to leave a sustained selection mode.
- In-flight `draggingSidebar` state is cleared on toggle to avoid orphaned drag state.