### PR TITLE
fix: focus diffview when showFileTree is false

### DIFF
--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -98,10 +98,15 @@ type mainModel struct {
 }
 
 func New(input string, cfg config.Config) mainModel {
+	initialPanel := FileTreePanel
+	if !cfg.UI.ShowFileTree {
+		initialPanel = DiffViewerPanel
+	}
+
 	m := mainModel{
 		input:             input,
 		isShowingFileTree: cfg.UI.ShowFileTree,
-		activePanel:       FileTreePanel,
+		activePanel:       initialPanel,
 		config:            cfg,
 		iconStyle:         cfg.UI.Icons,
 		sideBySide:        cfg.UI.SideBySide,

--- a/pkg/ui/tui_test.go
+++ b/pkg/ui/tui_test.go
@@ -181,6 +181,30 @@ func TestSearchSidebarDragMotionIsIgnored(t *testing.T) {
 	}
 }
 
+func TestInitialActivePanelWhenFileTreeIsHidden(t *testing.T) {
+	zone.NewGlobal()
+
+	cfg := config.DefaultConfig()
+	cfg.UI.ShowFileTree = false
+
+	data, err := os.ReadFile("../../examples/multiple_files.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(string(data), cfg)
+
+	if m.activePanel != DiffViewerPanel {
+		t.Fatalf(
+			"expected activePanel to be DiffViewerPanel when showFileTree is false, got %v",
+			m.activePanel,
+		)
+	}
+	if m.isShowingFileTree {
+		t.Fatal("expected file tree to be hidden when showFileTree is false")
+	}
+}
+
 func newTestMainModel(t *testing.T) mainModel {
 	t.Helper()
 	zone.NewGlobal()


### PR DESCRIPTION
# Summary

On startup, if the config option `showFileTree` is false, the panel is
collapsed and it's a weird UI experience that it is focused despite
being collapsed. Focus the diff panel on startup instead

- [n/a] Closes issue #...
- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

## AI disclosure

I used pi and anthropic, but fully understood the patch

## How Did You Test this Change?

I tested the updated `diffnav` with the code in this PR and verified it focused
the diff when started with the `showFileTree` config option enabled
