### PR TITLE
fix: pass non-unified-diff input through to stdout (closes #115)

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -1,0 +1,15 @@
+package cmd
+
+import "strings"
+
+// isUnifiedDiff reports whether the input looks like a git unified-diff stream
+// (the format the TUI is built to render).
+//
+// `git diff` and `git show` produce unified diffs that always contain at least
+// one `diff --git ` header line, regardless of which dialect of the diff
+// command was invoked. Summary forms (`--stat`, `--shortstat`, `--name-only`,
+// `--name-status`) and metadata-only commands (`git log` with no patch) emit
+// other shapes that the renderer cannot consume.
+func isUnifiedDiff(input string) bool {
+	return strings.Contains(input, "diff --git ")
+}

--- a/cmd/input_test.go
+++ b/cmd/input_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import "testing"
+
+func TestIsUnifiedDiff(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name: "git diff (unified)",
+			input: "diff --git a/foo.go b/foo.go\n" +
+				"index 1234567..89abcde 100644\n" +
+				"--- a/foo.go\n" +
+				"+++ b/foo.go\n" +
+				"@@ -1,3 +1,4 @@\n" +
+				" package foo\n" +
+				"+\n" +
+				" func A() {}\n",
+			want: true,
+		},
+		{
+			name: "git show (preamble + unified)",
+			input: "commit abc1234567890\n" +
+				"Author: Someone <s@example.com>\n" +
+				"Date:   Mon Jan 1 00:00:00 2026 +0000\n" +
+				"\n" +
+				"    subject\n" +
+				"\n" +
+				"diff --git a/foo.go b/foo.go\n" +
+				"@@ -1 +1,2 @@\n" +
+				" a\n+b\n",
+			want: true,
+		},
+		{
+			name: "git diff --stat",
+			input: " main.go | 5 ++---\n" +
+				" foo.go  | 1 +\n" +
+				" 2 files changed, 3 insertions(+), 3 deletions(-)\n",
+			want: false,
+		},
+		{
+			name:  "git diff --shortstat",
+			input: " 2 files changed, 3 insertions(+), 3 deletions(-)\n",
+			want:  false,
+		},
+		{
+			name:  "git diff --name-only",
+			input: "main.go\nfoo.go\n",
+			want:  false,
+		},
+		{
+			name:  "git diff --name-status",
+			input: "M\tmain.go\nA\tfoo.go\n",
+			want:  false,
+		},
+		{
+			name: "git log (no patch)",
+			input: "commit abc1234567890\n" +
+				"Author: Someone <s@example.com>\n" +
+				"Date:   Mon Jan 1 00:00:00 2026 +0000\n" +
+				"\n" +
+				"    subject\n",
+			want: false,
+		},
+		{
+			name:  "empty",
+			input: "",
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isUnifiedDiff(tc.input)
+			if got != tc.want {
+				t.Fatalf("isUnifiedDiff(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -202,6 +202,24 @@ func init() {
 				fmt.Println("No input provided, exiting")
 				os.Exit(0)
 			}
+
+			// When configured as `pager.diff`, git pipes the output of every
+			// `git diff` invocation here, including non-unified-diff variants
+			// like `git diff --stat`, `--shortstat`, `--name-only`, and
+			// `--name-status`. Those produce summary text with no `diff --git`
+			// markers, which (a) gives the TUI zero files and panics with a
+			// divide-by-zero in the scrollbar renderer, and (b) leaks
+			// terminal-capability query bytes from bubbletea init back to the
+			// user's prompt. Pass such input straight through to stdout so the
+			// caller sees the same output they would have without diffnav as
+			// the configured pager.
+			if !isUnifiedDiff(input) {
+				fmt.Print(input)
+				if !strings.HasSuffix(input, "\n") {
+					fmt.Println()
+				}
+				os.Exit(0)
+			}
 		}
 
 		cfg := config.Load()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -203,16 +203,6 @@ func init() {
 				os.Exit(0)
 			}
 
-			// When configured as `pager.diff`, git pipes the output of every
-			// `git diff` invocation here, including non-unified-diff variants
-			// like `git diff --stat`, `--shortstat`, `--name-only`, and
-			// `--name-status`. Those produce summary text with no `diff --git`
-			// markers, which (a) gives the TUI zero files and panics with a
-			// divide-by-zero in the scrollbar renderer, and (b) leaks
-			// terminal-capability query bytes from bubbletea init back to the
-			// user's prompt. Pass such input straight through to stdout so the
-			// caller sees the same output they would have without diffnav as
-			// the configured pager.
 			if !isUnifiedDiff(input) {
 				fmt.Print(input)
 				if !strings.HasSuffix(input, "\n") {


### PR DESCRIPTION
## Summary

When diffnav is configured as `pager.diff` (per the README), git pipes the output of every `git diff` invocation through diffnav, including non-unified-diff variants like `git diff --stat`, `--shortstat`, `--name-only`, and `--name-status`. Those produce summary text with no `diff --git ` markers, which causes two latent bugs:

1. **Panic.** The `bluekeyes/go-gitdiff` parser returns zero files, the TUI tries to render a scrollbar over an empty viewport, and the program panics with `runtime error: integer divide by zero` in `RenderScrollbar` ([pkg/ui/common/scrollbar.go:18](https://github.com/dlvhdr/diffnav/blob/main/pkg/ui/common/scrollbar.go#L18)).
2. **Escape-sequence leak.** Before the panic, bubbletea's terminal-capability handshake leaks `[?2026\$p[?2027\$p` query bytes to the user's stdout — the symptom in the bug report.

## Fix

Detect non-unified-diff input early in `cmd/root.go` (after stdin is fully read, before opening the TTY) and pass it through verbatim. The caller sees the same output they would have without diffnav as the configured pager — same behaviour as `cat`/the implicit pager-fallthrough that other TUI pagers use for non-diff input.

Detection is a `strings.Contains(input, "diff --git ")` check, extracted into a small `isUnifiedDiff` helper for unit testing. Both `git diff` and `git show` always emit at least one `diff --git ` header in the unified form, so the check matches the TUI's actual input contract.

## Test plan

- [x] **8 new unit tests** in `cmd/input_test.go` covering:
  - `git diff` (unified)
  - `git show` (preamble + unified)
  - `git diff --stat`
  - `git diff --shortstat`
  - `git diff --name-only`
  - `git diff --name-status`
  - `git log` (no patch)
  - empty input
- [x] **Empirically reproduced on Windows** with the canonical `--stat` output:
  - **Pre-fix**: `[?2026\$p[?2027\$p` bytes leak, then `runtime error: integer divide by zero` panic.
  - **Post-fix**: stat output is printed verbatim and diffnav exits 0.
- [x] **Real unified-diff input still routes to the TUI** (verified by piping `gh_dash_pr.diff` test fixture into the post-fix binary — TUI starts, hits the same pre-existing panic the upstream test environment hits, confirming the input is reaching the renderer).

## Notes

- The two pre-existing `pkg/ui/panes/filetree` test failures on `main` (`TestNoLastPath`, `TestCollapseTree`) are unrelated lipgloss-styling differences and not touched by this PR.
- This is a strict superset: any input that previously rendered now still renders; only inputs the renderer would have crashed on now exit gracefully.
- Closes #115. Should also fix the `git log` symptom from #28 (re-emerged after the recent v2 rewrite, since `git log` without `-p` produces no `diff --git ` line and would hit the same path).

## AI usage disclosure (per AI_POLICY.md)

Tool: Claude Code (Opus 4.7).
Extent: pattern analysis (root cause for the panic + escape leak), code drafting for the `isUnifiedDiff` helper and the early-return path, and the test cases. I reviewed every change manually, ran `go build`, `go test ./cmd/...`, and reproduced the pre-/post-fix behaviour locally on Windows before pushing. Happy to walk through any line on request.