### PR TITLE
fix(diffviewer): wrap long lines through delta in side-by-side, mark clipped lines in unified (closes #99)

### DIFF
--- a/pkg/ui/keys.go
+++ b/pkg/ui/keys.go
@@ -14,6 +14,8 @@ type KeyMap struct {
 	PrevFile        key.Binding
 	CtrlD           key.Binding
 	CtrlU           key.Binding
+	ScrollLeft      key.Binding
+	ScrollRight     key.Binding
 	ToggleFileTree  key.Binding
 	Search          key.Binding
 	Quit            key.Binding
@@ -71,6 +73,14 @@ var keys = &KeyMap{
 		key.WithKeys("ctrl+u"),
 		key.WithHelp("ctrl+u", "diff up"),
 	),
+	ScrollLeft: key.NewBinding(
+		key.WithKeys("left"),
+		key.WithHelp("←", "scroll left"),
+	),
+	ScrollRight: key.NewBinding(
+		key.WithKeys("right"),
+		key.WithHelp("→", "scroll right"),
+	),
 	ToggleFileTree: key.NewBinding(
 		key.WithKeys("e"),
 		key.WithHelp("e", "toggle file tree"),
@@ -124,6 +134,8 @@ func KeyGroups() [][]key.Binding {
 		keys.PrevFile,
 		keys.CtrlD,
 		keys.CtrlU,
+		keys.ScrollLeft,
+		keys.ScrollRight,
 	}, {
 		keys.ToggleFileTree,
 		keys.Search,

--- a/pkg/ui/panes/diffviewer/diffviewer.go
+++ b/pkg/ui/panes/diffviewer/diffviewer.go
@@ -80,11 +80,15 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 
 	case diffContentMsg:
-		// Truncate lines to viewport width to prevent ANSI escape overflow.
+		// Clip lines that exceed the viewport width and use a visible tail
+		// marker so users can see content was cut off rather than failing
+		// silently. In side-by-side mode delta wraps long lines for us; in
+		// unified mode delta passes them through as-is, so this clip-with-
+		// marker is the only signal that there's more to the right.
 		lines := strings.Split(msg.text, "\n")
 		for i, line := range lines {
 			if lipgloss.Width(line) > m.vp.Width() && m.vp.Width() > 0 {
-				lines[i] = ansi.Truncate(line, m.vp.Width(), "")
+				lines[i] = ansi.Truncate(line, m.vp.Width(), "…")
 			}
 		}
 		diff := strings.Join(lines, "\n")
@@ -304,7 +308,14 @@ func diffFile(node *cachedNode, width int, sideBySide bool) tea.Cmd {
 		args := []string{
 			"--paging=never",
 			fmt.Sprintf("-w=%d", width),
-			fmt.Sprintf("--max-line-length=%d", width),
+			// Disable hard truncation and let delta's own line-wrapping (active
+			// in side-by-side mode) carry the full line through. With
+			// `--max-line-length=<width>` and the default `--wrap-max-lines=2`,
+			// long lines were being clipped at the viewport before we saw
+			// them. Anything still wider than the viewport gets clipped with
+			// a visible "…" marker in the `diffContentMsg` handler.
+			"--max-line-length=0",
+			"--wrap-max-lines=unlimited",
 		}
 		if useSideBySide {
 			args = append(args, "--side-by-side")
@@ -340,7 +351,9 @@ func diffDir(dir *cachedNode, width int, sideBySide bool, preamble string) tea.C
 			fmt.Sprintf("--file-style='%s bold %s'", c, c),
 			fmt.Sprintf("--file-decoration-style='%s box %s'", c, c),
 			fmt.Sprintf("-w=%d", width),
-			fmt.Sprintf("--max-line-length=%d", width),
+			// See `diffFile` for why these are set this way.
+			"--max-line-length=0",
+			"--wrap-max-lines=unlimited",
 		}
 		if useSideBySide {
 			args = append(args, "--side-by-side")

--- a/pkg/ui/panes/diffviewer/diffviewer.go
+++ b/pkg/ui/panes/diffviewer/diffviewer.go
@@ -10,7 +10,6 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
-	"github.com/charmbracelet/x/ansi"
 
 	"github.com/dlvhdr/diffnav/pkg/filenode"
 	"github.com/dlvhdr/diffnav/pkg/icons"
@@ -45,8 +44,6 @@ type Model struct {
 	cache      nodeCache
 	sideBySide bool
 	preamble   string
-	rawText    string
-	xOffset    int
 }
 
 // SetPreamble stores the preamble text (e.g. commit metadata from git show).
@@ -85,9 +82,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		if _, ok := m.cache[msg.cacheKey]; ok {
 			m.cache[msg.cacheKey].diff = msg.text
 		}
-		m.rawText = msg.text
-		m.xOffset = 0
-		m.renderViewport()
+		m.vp.SetContent(msg.text)
 	}
 
 	return m, tea.Batch(cmds...)
@@ -122,9 +117,7 @@ func (m *Model) diff() tea.Cmd {
 		key := cacheKey(m.file.path, m.sideBySide)
 		if cached, ok := m.cache[key]; ok && cached.diff != "" {
 			m.file = cached
-			m.rawText = cached.diff
-			m.xOffset = 0
-			m.renderViewport()
+			m.vp.SetContent(cached.diff)
 			return nil
 		}
 		node := &cachedNode{
@@ -140,9 +133,7 @@ func (m *Model) diff() tea.Cmd {
 		key := cacheKey(m.dir.path, m.sideBySide)
 		if cached, ok := m.cache[key]; ok && cached.diff != "" {
 			m.dir = cached
-			m.rawText = cached.diff
-			m.xOffset = 0
-			m.renderViewport()
+			m.vp.SetContent(cached.diff)
 			return nil
 		}
 		node := &cachedNode{
@@ -213,9 +204,7 @@ func (m Model) SetFilePatch(file *gitdiff.File) (Model, tea.Cmd) {
 	key := cacheKey(fname, m.sideBySide)
 	if cached, ok := m.cache[key]; ok {
 		m.file = cached
-		m.rawText = cached.diff
-		m.xOffset = 0
-		m.renderViewport()
+		m.vp.SetContent(cached.diff)
 		return m, nil
 	}
 
@@ -239,9 +228,7 @@ func (m Model) SetDirPatch(dirPath string, files []*gitdiff.File) (Model, tea.Cm
 	key := cacheKey(dirPath, m.sideBySide)
 	if cached, ok := m.cache[key]; ok {
 		m.dir = cached
-		m.rawText = cached.diff
-		m.xOffset = 0
-		m.renderViewport()
+		m.vp.SetContent(cached.diff)
 		return m, nil
 	}
 
@@ -295,83 +282,14 @@ func (m *Model) ScrollTop() {
 	m.vp.GotoTop()
 }
 
-func (m *Model) scrollStep() int {
-	step := m.vp.Width() / 2
-	if step < 1 {
-		step = 1
-	}
-	return step
-}
-
-// ScrollLeft scrolls the viewport horizontally toward column 0.
+// ScrollLeft scrolls the viewport one column toward column 0.
 func (m *Model) ScrollLeft() {
-	if m.xOffset == 0 {
-		return
-	}
-	m.xOffset -= m.scrollStep()
-	if m.xOffset < 0 {
-		m.xOffset = 0
-	}
-	m.renderViewport()
+	m.vp.ScrollLeft(1)
 }
 
-// ScrollRight advances xOffset only if at least one line still has content
-// past the visible window.
+// ScrollRight scrolls the viewport one column away from column 0.
 func (m *Model) ScrollRight() {
-	if m.rawText == "" {
-		return
-	}
-	vpW := m.vp.Width()
-	if vpW <= 0 {
-		return
-	}
-	limit := m.xOffset + vpW
-	for _, line := range strings.Split(m.rawText, "\n") {
-		if lipgloss.Width(line) > limit {
-			m.xOffset += m.scrollStep()
-			m.renderViewport()
-			return
-		}
-	}
-}
-
-func (m *Model) renderViewport() {
-	if m.rawText == "" {
-		return
-	}
-	vpW := m.vp.Width()
-	if vpW <= 0 {
-		m.vp.SetContent(m.rawText)
-		return
-	}
-	lines := strings.Split(m.rawText, "\n")
-	for i, line := range lines {
-		lw := lipgloss.Width(line)
-		if m.xOffset == 0 && lw <= vpW {
-			continue
-		}
-		leftMark := m.xOffset > 0 && lw > m.xOffset
-		rightMark := lw > m.xOffset+vpW
-		budget := vpW
-		if leftMark {
-			budget--
-		}
-		if rightMark {
-			budget--
-		}
-		if budget < 0 {
-			budget = 0
-		}
-		sliced := ansi.Cut(line, m.xOffset, m.xOffset+budget)
-		if leftMark {
-			sliced = "…" + sliced
-		}
-		if rightMark {
-			sliced = sliced + "…"
-		}
-		lines[i] = sliced
-	}
-	m.vp.SetContent(strings.Join(lines, "\n"))
+	m.vp.ScrollRight(1)
 }
 
 func diffFile(node *cachedNode, width int, sideBySide bool) tea.Cmd {

--- a/pkg/ui/panes/diffviewer/diffviewer.go
+++ b/pkg/ui/panes/diffviewer/diffviewer.go
@@ -45,6 +45,8 @@ type Model struct {
 	cache      nodeCache
 	sideBySide bool
 	preamble   string
+	rawText    string
+	xOffset    int
 }
 
 // SetPreamble stores the preamble text (e.g. commit metadata from git show).
@@ -80,22 +82,12 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 
 	case diffContentMsg:
-		// Clip lines that exceed the viewport width and use a visible tail
-		// marker so users can see content was cut off rather than failing
-		// silently. In side-by-side mode delta wraps long lines for us; in
-		// unified mode delta passes them through as-is, so this clip-with-
-		// marker is the only signal that there's more to the right.
-		lines := strings.Split(msg.text, "\n")
-		for i, line := range lines {
-			if lipgloss.Width(line) > m.vp.Width() && m.vp.Width() > 0 {
-				lines[i] = ansi.Truncate(line, m.vp.Width(), "…")
-			}
-		}
-		diff := strings.Join(lines, "\n")
 		if _, ok := m.cache[msg.cacheKey]; ok {
-			m.cache[msg.cacheKey].diff = diff
+			m.cache[msg.cacheKey].diff = msg.text
 		}
-		m.vp.SetContent(diff)
+		m.rawText = msg.text
+		m.xOffset = 0
+		m.renderViewport()
 	}
 
 	return m, tea.Batch(cmds...)
@@ -130,7 +122,9 @@ func (m *Model) diff() tea.Cmd {
 		key := cacheKey(m.file.path, m.sideBySide)
 		if cached, ok := m.cache[key]; ok && cached.diff != "" {
 			m.file = cached
-			m.vp.SetContent(cached.diff)
+			m.rawText = cached.diff
+			m.xOffset = 0
+			m.renderViewport()
 			return nil
 		}
 		node := &cachedNode{
@@ -146,7 +140,9 @@ func (m *Model) diff() tea.Cmd {
 		key := cacheKey(m.dir.path, m.sideBySide)
 		if cached, ok := m.cache[key]; ok && cached.diff != "" {
 			m.dir = cached
-			m.vp.SetContent(cached.diff)
+			m.rawText = cached.diff
+			m.xOffset = 0
+			m.renderViewport()
 			return nil
 		}
 		node := &cachedNode{
@@ -217,7 +213,9 @@ func (m Model) SetFilePatch(file *gitdiff.File) (Model, tea.Cmd) {
 	key := cacheKey(fname, m.sideBySide)
 	if cached, ok := m.cache[key]; ok {
 		m.file = cached
-		m.vp.SetContent(cached.diff)
+		m.rawText = cached.diff
+		m.xOffset = 0
+		m.renderViewport()
 		return m, nil
 	}
 
@@ -241,7 +239,9 @@ func (m Model) SetDirPatch(dirPath string, files []*gitdiff.File) (Model, tea.Cm
 	key := cacheKey(dirPath, m.sideBySide)
 	if cached, ok := m.cache[key]; ok {
 		m.dir = cached
-		m.vp.SetContent(cached.diff)
+		m.rawText = cached.diff
+		m.xOffset = 0
+		m.renderViewport()
 		return m, nil
 	}
 
@@ -293,6 +293,85 @@ func (m *Model) ScrollBottom() {
 // ScrollTop scrolls the viewport to its top.
 func (m *Model) ScrollTop() {
 	m.vp.GotoTop()
+}
+
+func (m *Model) scrollStep() int {
+	step := m.vp.Width() / 2
+	if step < 1 {
+		step = 1
+	}
+	return step
+}
+
+// ScrollLeft scrolls the viewport horizontally toward column 0.
+func (m *Model) ScrollLeft() {
+	if m.xOffset == 0 {
+		return
+	}
+	m.xOffset -= m.scrollStep()
+	if m.xOffset < 0 {
+		m.xOffset = 0
+	}
+	m.renderViewport()
+}
+
+// ScrollRight advances xOffset only if at least one line still has content
+// past the visible window.
+func (m *Model) ScrollRight() {
+	if m.rawText == "" {
+		return
+	}
+	vpW := m.vp.Width()
+	if vpW <= 0 {
+		return
+	}
+	limit := m.xOffset + vpW
+	for _, line := range strings.Split(m.rawText, "\n") {
+		if lipgloss.Width(line) > limit {
+			m.xOffset += m.scrollStep()
+			m.renderViewport()
+			return
+		}
+	}
+}
+
+func (m *Model) renderViewport() {
+	if m.rawText == "" {
+		return
+	}
+	vpW := m.vp.Width()
+	if vpW <= 0 {
+		m.vp.SetContent(m.rawText)
+		return
+	}
+	lines := strings.Split(m.rawText, "\n")
+	for i, line := range lines {
+		lw := lipgloss.Width(line)
+		if m.xOffset == 0 && lw <= vpW {
+			continue
+		}
+		leftMark := m.xOffset > 0 && lw > m.xOffset
+		rightMark := lw > m.xOffset+vpW
+		budget := vpW
+		if leftMark {
+			budget--
+		}
+		if rightMark {
+			budget--
+		}
+		if budget < 0 {
+			budget = 0
+		}
+		sliced := ansi.Cut(line, m.xOffset, m.xOffset+budget)
+		if leftMark {
+			sliced = "…" + sliced
+		}
+		if rightMark {
+			sliced = sliced + "…"
+		}
+		lines[i] = sliced
+	}
+	m.vp.SetContent(strings.Join(lines, "\n"))
 }
 
 func diffFile(node *cachedNode, width int, sideBySide bool) tea.Cmd {

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -303,6 +303,14 @@ func (m mainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				m.diffViewer.ScrollTop()
 			}
+		case key.Matches(msg, keys.ScrollLeft):
+			if m.activePanel != FileTreePanel {
+				m.diffViewer.ScrollLeft()
+			}
+		case key.Matches(msg, keys.ScrollRight):
+			if m.activePanel != FileTreePanel {
+				m.diffViewer.ScrollRight()
+			}
 		case key.Matches(msg, keys.Copy):
 			cmd = m.fileTree.CopyCurrNodePath()
 			if cmd != nil {


### PR DESCRIPTION
## Summary

Closes #99.

`diffFile` and `diffDir` invoke delta with `--max-line-length=<width>`, which is the **truncation** flag — not a wrap hint. Combined with delta's default `--wrap-max-lines=2`, any source line longer than roughly two viewport widths got silently dropped in side-by-side mode. In unified mode (where delta does not wrap at all) the long line then hit the post-processing truncation in the `diffContentMsg` handler, which used an empty tail (`""`) and clipped without any visible signal.

The reporter pointed at both spots in the original issue — both [the delta args](https://github.com/dlvhdr/diffnav/blob/2898ff7523b89f683d52c639789e7d404627b0b9/pkg/ui/panes/diffviewer/diffviewer.go#L282-L294) and [the post-processing pass](https://github.com/dlvhdr/diffnav/blob/2898ff7523b89f683d52c639789e7d404627b0b9/pkg/ui/panes/diffviewer/diffviewer.go#L82-L95).

## Fix

Two changes in `pkg/ui/panes/diffviewer/diffviewer.go`, plus horizontal scrolling added per review feedback:

1. **`diffFile` and `diffDir`** — replace `--max-line-length=<width>` with `--max-line-length=0` (disable truncation) and add `--wrap-max-lines=unlimited`. Side-by-side mode now wraps long lines all the way through instead of stopping at the second wrap.

2. **`diffContentMsg` handler** — store the raw delta output, render the visible window on every change. The cache now holds raw text, so cache hits re-render through the same path.

3. **Horizontal scrolling** (added in response to https://github.com/dlvhdr/diffnav/pull/133#discussion_r3249687214):
   - Left / right arrow keys scroll the diff viewport horizontally at half-viewport step. `h`/`l` are taken by file-tree expand/collapse, so arrows are the only sensible binding.
   - `xOffset` resets to `0` whenever a new file or dir is loaded.
   - The `…` markers are conditional: right when `lineWidth > xOffset + viewportWidth`, left when `xOffset > 0 && lineWidth > xOffset`. A line shorter than the viewport never shows either marker.

## Verification

Local repro with the canonical "very long line" diff at `-w=80`:

| Mode | Pre-fix | Post-fix |
|---|---|---|
| **Side-by-side** | clipped at *"what flags delta is invoked with"* (≈2 wraps) | reaches *"to see what happens here"* (full content) |
| **Unified** | line silently cut at viewport width with no marker | line cut with `…` tail; right-arrow scrolls to reveal the rest, `…` appears on the left once scrolled |

Verified delta args directly:

```
$ delta --paging=never -w=80 --max-line-length=0 --wrap-max-lines=unlimited --side-by-side < long.diff
…
│    │                                  │  2 │const Long = "this is a very long↵
│    │                                  │    │ line that should be wrapped or t↵
│    │                                  │    │runcated depending on what flags ↵
│    │                                  │    │delta is invoked with and we want↵
│    │                                  │    │ to see what happens here"
…
```

Existing `pkg/ui/panes/diffviewer` test suite passes:

```
ok  	github.com/dlvhdr/diffnav/pkg/ui/panes/diffviewer	0.366s
```

The pre-existing `TestSearchResultsRenderWhenFileTreeIsHidden`, `TestBuildFullFileTree`, and `TestCollapseTree` failures on `main` are unrelated lipgloss-styling drift and are not touched by this PR.

## AI usage disclosure (per AI_POLICY.md)

Tool: Claude Code (Opus 4.7).
Extent: pattern analysis (delta flag semantics, charmbracelet `ansi.Cut` usage), code drafting for the offset / render-window logic, and commit-message wording. I reviewed every change manually, ran `go build`, `go vet`, `go test ./pkg/ui/panes/diffviewer/...`, and confirmed the long-line repro behaviour locally before pushing. Happy to walk through any line on request.

Credit to @fgrehm for the report and the precise line references in the issue.